### PR TITLE
Allow attribute changes without source

### DIFF
--- a/lib/cia.rb
+++ b/lib/cia.rb
@@ -5,6 +5,7 @@ require 'cia/auditable'
 module CIA
   autoload 'Event', 'cia/event'
   autoload 'AttributeChange', 'cia/attribute_change'
+  autoload 'SourceValidation', 'cia/source_validation'
 
   class << self
     attr_accessor :exception_handler

--- a/lib/cia/attribute_change.rb
+++ b/lib/cia/attribute_change.rb
@@ -1,12 +1,12 @@
 module CIA
   class AttributeChange < ActiveRecord::Base
+    include SourceValidation
     self.table_name = "cia_attribute_changes"
 
     belongs_to :event, :foreign_key => "cia_event_id"
     belongs_to :source, :polymorphic => true
 
     validates_presence_of :event, :attribute_name
-    validates_presence_of :source, :if => :source_must_be_present?
 
     if ActiveRecord::VERSION::MAJOR > 2
       scope :previous, :order => "id desc"

--- a/lib/cia/event.rb
+++ b/lib/cia/event.rb
@@ -1,5 +1,6 @@
 module CIA
   class Event < ActiveRecord::Base
+    include SourceValidation
     self.table_name = "cia_events"
 
     belongs_to :actor, :polymorphic => true
@@ -7,8 +8,6 @@ module CIA
     has_many :attribute_changes, :foreign_key => :cia_event_id
 
     validates_presence_of :action
-    validates_presence_of :source, :if => :source_must_be_present?
-    validates_presence_of :source_id, :source_type, :unless => :source_must_be_present?
 
     def self.previous
       scoped(:order => "created_at desc")

--- a/lib/cia/source_validation.rb
+++ b/lib/cia/source_validation.rb
@@ -1,0 +1,8 @@
+module CIA
+  module SourceValidation
+    def self.included(base)
+      base.validates_presence_of :source_id, :source_type, :unless => :source_must_be_present?
+      base.validates_presence_of :source, :if => :source_must_be_present?
+    end
+  end
+end

--- a/spec/cia/attribute_change_spec.rb
+++ b/spec/cia/attribute_change_spec.rb
@@ -56,7 +56,8 @@ describe CIA::AttributeChange do
     it "does not require a source when associated event does not" do
       event = CIA::Event.new(:id => 1)
       event.stub(:source_must_be_present? => false)
-      change = CIA::AttributeChange.new(:event => event, :attribute_name => 'awesomeness')
+      change = CIA::AttributeChange.new(:event => event, :attribute_name => 'awesomeness',
+                                        :source_type => 'ObscureType', :source_id => 101)
 
       change.valid?.should be_true
     end


### PR DESCRIPTION
This will allow attribute changes to be saved without having the class that contains the change available.
The `validates_presence_of` method tries to load the class associated with the attribute change because of the polymorphic association on `source` this is a problem when the project that handles auditing does not contain the classes for the audited change.
I chose to follow the rules on the `Event` class for determining the need for a source. It might also require some protection on the `source` association as well.

/cc @grosser
